### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-warriorwellness.me


### PR DESCRIPTION
This CNAME file should not be added to the gh-pages branch deployment. It was added initially since we owned the domain warriorwellness.me and we wanted our github pages deployment to route to warriorwellness.me (and vice versa). Since **we no longer own the domain** please **do not add the file to this branch** since it will cause github to think that our website is hosted on warriorwellness.me instead of paramshah10.github.io/warrior-wellness (hence the automatic redirect from paramshah10.github.io/warrior-wellness to warriorwelness.me).